### PR TITLE
RxSwiftをCombineに置き換え

### DIFF
--- a/Domain/Repository/TotoDataRepository.swift
+++ b/Domain/Repository/TotoDataRepository.swift
@@ -6,13 +6,13 @@
 //  Created by kosou.tei on 2021/05/13.
 //
 
-import RxSwift
+import Combine
 
 public protocol TotoDataRepository {
-    func getHeldData() -> Single<Int?>
-    func getHeldDetailData(heldNumber: Int) -> Single<Held?>
-    func getTotoRateData(heldNumber: Int) -> Single<([Frame], [Rate])?>
-    func getBookRateData(heldNumber: Int) -> Single<[Rate]?>
+    func getHeldData() -> Future<Int? ,Error>
+    func getHeldDetailData(heldNumber: Int) -> Future<Held?, Error>
+    func getTotoRateData(heldNumber: Int) -> Future<([Frame], [Rate])?, Error>
+    func getBookRateData(heldNumber: Int) -> Future<[Rate]?, Error>
     func getHeld() -> Held?
     func saveHeld(_ held: Held) -> Bool
 }

--- a/Domain/UseCase/IF/DataHandleUseCase.swift
+++ b/Domain/UseCase/IF/DataHandleUseCase.swift
@@ -5,13 +5,13 @@
 //  Created by kosou.tei on 2021/05/14.
 //
 
-import RxSwift
+import Combine
 
 public protocol DataHandleUseCase {
-    func getHeldData() -> Single<Int?>
-    func getHeldDetailData(heldNumber: Int) -> Single<Held?>
-    func getTotoRateData(heldNumber: Int) -> Single<([Frame], [Rate])?>
-    func getBookRateData(heldNumber: Int) -> Single<[Rate]?>
+    func getHeldData() -> Future<Int?, Error>
+    func getHeldDetailData(heldNumber: Int) -> Future<Held?, Error>
+    func getTotoRateData(heldNumber: Int) -> Future<([Frame], [Rate])?, Error>
+    func getBookRateData(heldNumber: Int) -> Future<[Rate]?, Error>
     func getHeld() -> Held?
     func saveHeld(_ held: Held) -> Bool
 }

--- a/Domain/UseCase/Impl/DataHandleUseCaseImpl.swift
+++ b/Domain/UseCase/Impl/DataHandleUseCaseImpl.swift
@@ -6,7 +6,7 @@
 //  Created by kosou.tei on 2021/05/14.
 //
 
-import RxSwift
+import Combine
 
 public class DataHandleUseCaseImpl: DataHandleUseCase {
     
@@ -16,19 +16,19 @@ public class DataHandleUseCaseImpl: DataHandleUseCase {
         self.totoDataRepository = totoDataRepository
     }
     
-    public func getHeldData() -> Single<Int?> {
+    public func getHeldData() -> Future<Int?, Error> {
         self.totoDataRepository.getHeldData()
     }
     
-    public func getHeldDetailData(heldNumber: Int) -> Single<Held?> {
+    public func getHeldDetailData(heldNumber: Int) -> Future<Held?, Error> {
         self.totoDataRepository.getHeldDetailData(heldNumber: heldNumber)
     }
     
-    public func getTotoRateData(heldNumber: Int) -> Single<([Frame], [Rate])?> {
+    public func getTotoRateData(heldNumber: Int) -> Future<([Frame], [Rate])?, Error> {
         self.totoDataRepository.getTotoRateData(heldNumber: heldNumber)
     }
     
-    public func getBookRateData(heldNumber: Int) -> Single<[Rate]?> {
+    public func getBookRateData(heldNumber: Int) -> Future<[Rate]?, Error> {
         self.totoDataRepository.getBookRateData(heldNumber: heldNumber)
     }
     

--- a/Infra/DataSource/RemoteDataSource.swift
+++ b/Infra/DataSource/RemoteDataSource.swift
@@ -7,14 +7,14 @@
 //
 
 import Alamofire
-import RxSwift
+import Combine
 import Domain
 
 class RemoteDataSource {
     // 開催回データ取得
-    public func getHeldData() -> Single<Int?> {
+    public func getHeldData() -> Future<Int?, Error> {
         let url = "https://toto.rakuten.co.jp/toto/schedule/"
-        return Single.create { subscriber in
+        return Future<Int?, Error> { subscriber in
             AF.request(url).responseString { response in
                 switch response.result {
                 case .success(let html):
@@ -23,14 +23,13 @@ class RemoteDataSource {
                     subscriber(.failure(error))
                 }
             }
-            return Disposables.create()
         }
     }
     
     // 開催詳細データ取得
-    public func getHeldDetailData(heldNumber: Int) -> Single<Held?> {
+    public func getHeldDetailData(heldNumber: Int) -> Future<Held?, Error> {
         let url = "https://store.toto-dream.com/dcs/subos/screen/pi01/spin000/PGSPIN00001DisptotoLotInfo.form?holdCntId=\(heldNumber)"
-        return Single.create { subscriber in
+        return Future<Held?, Error> { subscriber in
             AF.request(url).responseString { response in
                 switch response.result {
                 case .success(let html):
@@ -39,14 +38,13 @@ class RemoteDataSource {
                     subscriber(.failure(error))
                 }
             }
-            return Disposables.create()
         }
     }
     
     // Toto支持率データ取得
-    public func getTotoRateData(heldNumber: Int) -> Single<([Frame], [Rate])?> {
+    public func getTotoRateData(heldNumber: Int) -> Future<([Frame], [Rate])?, Error> {
         let url = "https://store.toto-dream.com/dcs/subos/screen/pi09/spin003/PGSPIN00301InitVoteRate.form?holdCntId=\(heldNumber)&commodityId=01"
-        return Single.create { subscriber in
+        return Future<([Frame], [Rate])?, Error> { subscriber in
             AF.request(url).responseString { response in
                 switch response.result {
                 case .success(let html):
@@ -55,15 +53,14 @@ class RemoteDataSource {
                     subscriber(.failure(error))
                 }
             }
-            return Disposables.create()
         }
     }
     
     // Book支持率データ取得
-    public func getBookRateData(heldNumber: Int) -> Single<[Rate]?> {
+    public func getBookRateData(heldNumber: Int) -> Future<[Rate]?, Error> {
         // Bookデータのサイトがhttps対応してないのでATS無効にしてるけど、おそらくこれでは審査通らないね
         let url = "http://tobakushi.net/toto/tototimes/bg_\(heldNumber).html"
-        return Single.create { subscriber in
+        return Future<[Rate]?, Error> { subscriber in
             AF.request(url).responseString { response in
                 switch response.result {
                 case .success(let html):
@@ -72,7 +69,6 @@ class RemoteDataSource {
                     subscriber(.failure(error))
                 }
             }
-            return Disposables.create()
         }
     }
 }

--- a/Infra/Repository/TotoDataRepositoryImpl.swift
+++ b/Infra/Repository/TotoDataRepositoryImpl.swift
@@ -6,31 +6,31 @@
 //  Created by kosou.tei on 2021/05/13.
 //
 
-import RxSwift
+import Combine
 import Domain
 
 public class TotoDataRepositoryImpl: TotoDataRepository {
     
     let localDataSource = LocalDataSource()
     let remoteDataSource = RemoteDataSource()
-
+ 
     // 開催回データ取得
-    public func getHeldData() -> Single<Int?> {
+    public func getHeldData() -> Future<Int? ,Error> {
         remoteDataSource.getHeldData()
     }
 
     // 開催詳細データ取得
-    public func getHeldDetailData(heldNumber: Int) -> Single<Held?> {
+    public func getHeldDetailData(heldNumber: Int) -> Future<Held?, Error> {
         remoteDataSource.getHeldDetailData(heldNumber: heldNumber)
     }
 
     // Toto支持率データ取得
-    public func getTotoRateData(heldNumber: Int) -> Single<([Frame], [Rate])?> {
+    public func getTotoRateData(heldNumber: Int) -> Future<([Frame], [Rate])?, Error> {
         remoteDataSource.getTotoRateData(heldNumber: heldNumber)
     }
 
     // Book支持率データ取得
-    public func getBookRateData(heldNumber: Int) -> Single<[Rate]?> {
+    public func getBookRateData(heldNumber: Int) -> Future<[Rate]?, Error> {
         remoteDataSource.getBookRateData(heldNumber: heldNumber)
     }
     

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,6 @@ target 'Infra' do
   use_frameworks!
   pod "Alamofire", "5.4.3"
   pod "Kanna", "5.2.4"
-  pod "RxSwift", "6.1.0"
   pod "Disk", "0.6.4"
   
   target 'TotoRan' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,14 +5,12 @@ PODS:
   - NVActivityIndicatorView (4.8.0):
     - NVActivityIndicatorView/Presenter (= 4.8.0)
   - NVActivityIndicatorView/Presenter (4.8.0)
-  - RxSwift (6.1.0)
 
 DEPENDENCIES:
   - Alamofire (= 5.4.3)
   - Disk (= 0.6.4)
   - Kanna (= 5.2.4)
   - NVActivityIndicatorView (= 4.8.0)
-  - RxSwift (= 6.1.0)
 
 SPEC REPOS:
   trunk:
@@ -20,15 +18,13 @@ SPEC REPOS:
     - Disk
     - Kanna
     - NVActivityIndicatorView
-    - RxSwift
 
 SPEC CHECKSUMS:
   Alamofire: e447a2774a40c996748296fa2c55112fdbbc42f9
   Disk: dcee5c2e98fb72f9a924cde8da8435b08244a80e
   Kanna: b9d00d7c11428308c7f95e1f1f84b8205f567a8f
   NVActivityIndicatorView: d24b7ebcf80af5dcd994adb650e2b6c93379270f
-  RxSwift: a834e5c538e89eca0cae86f403f4fbf0336786ce
 
-PODFILE CHECKSUM: 4d0708787853151a916e5901f3c64de135a3555b
+PODFILE CHECKSUM: 71b626bb8a8ce078293d899150f0fcada9a31f4c
 
 COCOAPODS: 1.10.1

--- a/TotoRan.xcodeproj/project.pbxproj
+++ b/TotoRan.xcodeproj/project.pbxproj
@@ -1496,7 +1496,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = tei.kosou.TotoRan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
@@ -1520,7 +1520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = tei.kosou.TotoRan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";

--- a/TotoRan/ViewController/InitialViewController.swift
+++ b/TotoRan/ViewController/InitialViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import RxSwift
+import Combine
 import NVActivityIndicatorView
 
 enum InitialViewAlertReason: String {


### PR DESCRIPTION
- SwiftUI + MVVM化に向けての前作業としてRxSwiftでのリアクティブプログラミングをApple標準のCombineに置き換えた。
    - CocoaPodsからRxSwiftを削除
    - ソースコードを置き換え (基本はSingle → Future)